### PR TITLE
Paginate ebs_snapshot_count check

### DIFF
--- a/aws_quota/check/ebs.py
+++ b/aws_quota/check/ebs.py
@@ -10,4 +10,4 @@ class SnapshotCountCheck(QuotaCheck):
 
     @property
     def current(self):
-        return len(self.boto_session.client('ec2').describe_snapshots(OwnerIds=['self'])['Snapshots'])
+        return self.count_paginated_results("ec2", "describe_snapshots", "Snapshots", {"OwnerIds": ["self"]})

--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -29,7 +29,8 @@ class QuotaCheck:
 
     def count_paginated_results(self, service: str, method: str, key: str, paginate_args: dict = {}) -> int:
         paginator = self.boto_session.client(service).get_paginator(method)
-        page_iterable = paginator.paginate(**paginate_args)
+        pagination_config = {'PageSize': 1000}
+        page_iterable = paginator.paginate(**{"PaginationConfig": pagination_config, **paginate_args})
         return sum(len(page[key]) for page in page_iterable)
 
     @property

--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -29,7 +29,7 @@ class QuotaCheck:
 
     def count_paginated_results(self, service: str, method: str, key: str, paginate_args: dict = {}) -> int:
         paginator = self.boto_session.client(service).get_paginator(method)
-        pagination_config = {'PageSize': 1000}
+        pagination_config = {'PageSize': 100}
         page_iterable = paginator.paginate(**{"PaginationConfig": pagination_config, **paginate_args})
         return sum(len(page[key]) for page in page_iterable)
 

--- a/aws_quota/prometheus.py
+++ b/aws_quota/prometheus.py
@@ -181,7 +181,7 @@ class PrometheusExporter:
                         checks_to_drop.append(e.check)
                     except Exception:
                         logger.error(
-                            'getting maximum of quota %s failed', check)
+                            'getting current value of quota %s failed', check)
 
                 for check in checks_to_drop:
                     self.checks.remove(check)


### PR DESCRIPTION
This PR fixes a memory usage issue whereby quota checks make a single `boto3` call, even when supposedly paginating. Symptoms described in [this comment](https://github.com/brennerm/aws-quota-checker/issues/31#issuecomment-1007140565) on #31.
- Uses the existing paginator to count the `ebs_snapshot_count` quota
- Sets a default pagination page size (otherwise the paginator just gets all resources in my testing of `describe_snapshots`)
- Fixes up an error log message

See memory usage spikes to ~800 MiB on `1.10.0` and is fairly stable at ~50 MiB on this branch.
![image](https://user-images.githubusercontent.com/13642138/148519980-41f9ec31-cae8-4147-bcf0-a5f6b4b64896.png)

Before:
- Locally
  ```
  $ time aws-quota-checker check ebs_snapshot_count

  AWS profile: default | AWS region: ap-southeast-2 | Active checks: ebs_snapshot_count
  EBS Snapshots per Region [xxx/ap-southeast-2]: 34896/100000 ✓
  aws-quota-checker check ebs_snapshot_count  12.72s user 2.32s system 3% cpu 7:27.41 total
  ```
- In cluster (~3 minutes):
  ```
  AWS profile: default | AWS region: ap-southeast-2 | Active checks: 
  cf_stack_count,ebs_snapshot_count,rds_instances,s3_bucket_count
  ...
  07-Jan-22 06:10:21 [INFO] aws_quota.prometheus - refreshing current values
  07-Jan-22 06:13:39 [INFO] aws_quota.prometheus - current values refreshed
  ```

After:
- Locally:
  ```
  $ time aws-quota-checker check ebs_snapshot_count

  AWS profile: default | AWS region: ap-southeast-2 | Active checks: ebs_snapshot_count
  EBS Snapshots per Region [xxx/ap-southeast-2]: 34899/100000 ✓
  aws-quota-checker check ebs_snapshot_count  12.33s user 1.36s system 16% cpu 1:25.01 total
  ```
- In cluster (~1 minute):
  ```
  AWS profile: default | AWS region: ap-southeast-2 | Active checks: 
  cf_stack_count,ebs_snapshot_count,rds_instances,s3_bucket_count
  ...
  07-Jan-22 08:47:46 [INFO] aws_quota.prometheus - refreshing current values
  07-Jan-22 08:48:55 [INFO] aws_quota.prometheus - current values refreshed
  ```