### PR TITLE
Add RDS snapshot quota checks

### DIFF
--- a/aws_quota/check/rds.py
+++ b/aws_quota/check/rds.py
@@ -45,3 +45,14 @@ class RDSEventSubscriptions(QuotaCheck):
     @property
     def current(self) -> int:
         return self.count_paginated_results("rds", "describe_event_subscriptions", "EventSubscriptionsList")
+
+class RDSDBSnapshotsCheck(QuotaCheck):
+    key = "rds_db_snapshots"
+    description = "Manual DB instance snapshots per Region"
+    service_code = "rds"
+    scope = QuotaScope.REGION
+    quota_code = "L-272F1212"
+
+    @property
+    def current(self) -> int:
+        return self.count_paginated_results("rds", "describe_db_snapshots", "DBSnapshots", {"SnapshotType": "manual"})

--- a/aws_quota/check/rds.py
+++ b/aws_quota/check/rds.py
@@ -58,7 +58,7 @@ class RDSEventSubscriptions(QuotaCheck):
 
 
 class RDSDBSnapshotsCheck(QuotaCheck):
-    key = "rds_db_snapshots"
+    key = "rds_instance_snapshots"
     description = "Manual DB instance snapshots per Region"
     service_code = "rds"
     scope = QuotaScope.REGION
@@ -72,7 +72,7 @@ class RDSDBSnapshotsCheck(QuotaCheck):
 
 
 class RDSDBClusterSnapshotsCheck(QuotaCheck):
-    key = "rds_db_cluster_snapshots"
+    key = "rds_cluster_snapshots"
     description = "Manual DB cluster snapshots per Region"
     service_code = "rds"
     scope = QuotaScope.REGION

--- a/aws_quota/check/rds.py
+++ b/aws_quota/check/rds.py
@@ -1,5 +1,6 @@
 from .quota_check import QuotaCheck, QuotaScope
 
+
 class RDSDBInstanceCountCheck(QuotaCheck):
     key = "rds_instances"
     description = "RDS instances per Region"
@@ -9,7 +10,10 @@ class RDSDBInstanceCountCheck(QuotaCheck):
 
     @property
     def current(self) -> int:
-        return self.count_paginated_results("rds", "describe_db_instances", "DBInstances")
+        return self.count_paginated_results(
+            "rds", "describe_db_instances", "DBInstances"
+        )
+
 
 class RDSDBParameterGroupsCountCheck(QuotaCheck):
     key = "rds_parameter_groups"
@@ -20,7 +24,9 @@ class RDSDBParameterGroupsCountCheck(QuotaCheck):
 
     @property
     def current(self) -> int:
-        return self.count_paginated_results("rds", "describe_db_parameter_groups", "DBParameterGroups")
+        return self.count_paginated_results(
+            "rds", "describe_db_parameter_groups", "DBParameterGroups"
+        )
 
 
 class RDSDBClusterParameterGroupCountCheck(QuotaCheck):
@@ -32,7 +38,9 @@ class RDSDBClusterParameterGroupCountCheck(QuotaCheck):
 
     @property
     def current(self) -> int:
-        return self.count_paginated_results("rds", "describe_db_cluster_parameter_groups", "DBClusterParameterGroups")
+        return self.count_paginated_results(
+            "rds", "describe_db_cluster_parameter_groups", "DBClusterParameterGroups"
+        )
 
 
 class RDSEventSubscriptions(QuotaCheck):
@@ -44,7 +52,10 @@ class RDSEventSubscriptions(QuotaCheck):
 
     @property
     def current(self) -> int:
-        return self.count_paginated_results("rds", "describe_event_subscriptions", "EventSubscriptionsList")
+        return self.count_paginated_results(
+            "rds", "describe_event_subscriptions", "EventSubscriptionsList"
+        )
+
 
 class RDSDBSnapshotsCheck(QuotaCheck):
     key = "rds_db_snapshots"
@@ -55,4 +66,6 @@ class RDSDBSnapshotsCheck(QuotaCheck):
 
     @property
     def current(self) -> int:
-        return self.count_paginated_results("rds", "describe_db_snapshots", "DBSnapshots", {"SnapshotType": "manual"})
+        return self.count_paginated_results(
+            "rds", "describe_db_snapshots", "DBSnapshots", {"SnapshotType": "manual"}
+        )

--- a/aws_quota/check/rds.py
+++ b/aws_quota/check/rds.py
@@ -69,3 +69,17 @@ class RDSDBSnapshotsCheck(QuotaCheck):
         return self.count_paginated_results(
             "rds", "describe_db_snapshots", "DBSnapshots", {"SnapshotType": "manual"}
         )
+
+
+class RDSDBClusterSnapshotsCheck(QuotaCheck):
+    key = "rds_db_cluster_snapshots"
+    description = "Manual DB cluster snapshots per Region"
+    service_code = "rds"
+    scope = QuotaScope.REGION
+    quota_code = "L-9B510759"
+
+    @property
+    def current(self) -> int:
+        return self.count_paginated_results(
+            "rds", "describe_db_cluster_snapshots", "DBClusterSnapshots", {"SnapshotType": "manual"}
+        )


### PR DESCRIPTION
Adds quota checks for `Manual DB cluster snapshots` and `Manual DB instance snapshots` https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Limits
![image](https://user-images.githubusercontent.com/13642138/149055707-c68b090f-76b8-4ef6-ac23-bc8d04df53fb.png)

```
$ aws-quota-checker check rds_db_snapshots,rds_db_cluster_snapshots
AWS profile: default | AWS region: ap-southeast-2 | Active checks: rds_db_cluster_snapshots,rds_db_snapshots
Collecting checks  [####################################]  100%
Manual DB cluster snapshots per Region [xxx/ap-southeast-2]: 0/200 ✓
Manual DB instance snapshots per Region [xxx/ap-southeast-2]: 152/200 ✓
```