### PR TITLE
Avoid TooManyRequestsException using backoff

### DIFF
--- a/aws_quota/prometheus.py
+++ b/aws_quota/prometheus.py
@@ -102,7 +102,7 @@ class PrometheusExporter:
                         else:
                             checks.append(chk(self.session))
                     except Exception:
-                        logger.error('failed to collect check %s', chk)
+                        logger.exception('failed to collect check %s', chk)
 
                 g.set(len(checks))
                 self.checks = checks
@@ -140,7 +140,7 @@ class PrometheusExporter:
                             'instance with identifier %s does not exist anymore, dropping it...', e.check.instance_id)
                         checks_to_drop.append(e.check)
                     except Exception:
-                        logger.error(
+                        logger.exception(
                             'getting maximum of quota %s failed', check)
 
                 for check in checks_to_drop:
@@ -180,7 +180,7 @@ class PrometheusExporter:
                             'instance with identifier %s does not exist anymore, dropping it...', e.check.instance_id)
                         checks_to_drop.append(e.check)
                     except Exception:
-                        logger.error(
+                        logger.exception(
                             'getting current value of quota %s failed', check)
 
                 for check in checks_to_drop:

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     install_requires=[
+        'backoff',
         'boto3',
         'click',
         'tabulate',


### PR DESCRIPTION
Adds `backoff` package to avoid `TooManyRequestsException` happened with high-rated requests.
https://docs.aws.amazon.com/servicequotas/2019-06-24/apireference/API_GetServiceQuota.html
Now there are retries:

```
12-Apr-22 16:57:04 [INFO] aws_quota.prometheus - starting /metrics endpoint on port 8080
12-Apr-22 16:57:04 [INFO] aws_quota.prometheus - collecting checks
12-Apr-22 16:57:22 [INFO] aws_quota.prometheus - collected 746 checks
12-Apr-22 16:57:22 [INFO] aws_quota.prometheus - refreshing limits
12-Apr-22 16:57:39 [INFO] backoff - Backing off _maximum(...) for 0.3s (botocore.errorfactory.TooManyRequestsException: An error occurred (TooManyRequestsException) when calling the GetServiceQuota operation: Rate exceeded)
12-Apr-22 16:57:41 [INFO] backoff - Backing off _maximum(...) for 0.6s (botocore.errorfactory.TooManyRequestsException: An error occurred (TooManyRequestsException) when calling the GetServiceQuota operation: Rate exceeded)
```

In addition I add traceback to logs when error still happens.